### PR TITLE
Include groups in channel list

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ util.inherits(Bot, EventEmitter);
 Bot.prototype.login = function() {
     this._api('rtm.start').then(function(data) {
         this.wsUrl = data.url;
-        this.channels = data.channels;
+        this.channels = data.channels.concat(data.groups);
         this.users = data.users;
         this.ims = data.ims;
 


### PR DESCRIPTION
I wanted to make a postMessageToChannel call for a private group the bot had been invited to, but since groups are part of a separate list from the data returned back during rtm.start, I had join the two lists together for a completed list.

Note that doesn't solve the problem of when it gets a list of channels [later on](https://github.com/mishk0/slack-bot-api/blob/master/index.js#L73), but because of the way you're using promises and I'm still a bit unfamiliar with how to best use them, I didn't include a fix to merge results from a channels.list and groups.list API call.