### PR TITLE
More Events types

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ npm install slackbots
 - `message` - event fired, when something happens in Slack. Description of all events <a href="https://api.slack.com/rtm">here</a>,
 - `open` - websocket connection is open and ready to communicate,
 - `close` - websocket connection is closed.
+- `on_[event name]` All events described on <a href="https://api.slack.com/rtm">slack api</a> are available as `[event name]`
 
 ### Methods
 
@@ -69,6 +70,14 @@ PROFIT!
  */
 bot.on('message', function(data) {
     // all ingoing events https://api.slack.com/rtm
+    console.log(data);
+});
+```
+
+Listen `user_typing` event name as in Slack RTM API documentation
+
+```js
+bot.on("on_user_typing", function(data) {
     console.log(data);
 });
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ npm install slackbots
 - `message` - event fired, when something happens in Slack. Description of all events <a href="https://api.slack.com/rtm">here</a>,
 - `open` - websocket connection is open and ready to communicate,
 - `close` - websocket connection is closed.
-- `on_[event name]` All events described on <a href="https://api.slack.com/rtm">slack api</a> are available as `[event name]`
+- `on_[event name]` - all events described on <a href="https://api.slack.com/rtm">slack api</a> are available as `[event name]`
+- `on_[event name]:[subtype]` - for listen the events include subtype, <a href="https://api.slack.com/events/message">example</a>
+- `on_[event name];` - for listen the events without subtype
 
 ### Methods
 
@@ -79,6 +81,24 @@ Listen `user_typing` event name as in Slack RTM API documentation
 ```js
 bot.on("on_user_typing", function(data) {
     console.log(data);
+});
+```
+
+Listen `message` event of bot's message
+
+```js
+bot.on("on_message:bot_message", function(data) {
+    console.log(data);
+});
+```
+
+The `on_message` event also include messages which post by Bot.  
+It can be define by `subtype` of the return message.  
+To avoid the loop effect we can listen pure `on_message` which without any `subtype`, by end the event name with `;` 
+
+```js
+bot.on("on_message;", function(data) {
+    console.log(data.subtype) // undefined;
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -56,11 +56,18 @@ Bot.prototype.connect = function() {
 
     this.ws.on('message', function(data) {
         try {
-          data = JSON.parse(data);
+            data = JSON.parse(data);
         } catch (e) {
-          console.log(e);
+            console.log(e);
         }
-        this.emit(data.type, data);
+
+        if (data.subtype) {
+            this.emit("on_" + data.type + ":" + data.subtype, data);
+        } else {
+            this.emit("on_" + data.type + ";", data);
+        }
+
+        this.emit("on_" + data.type, data);
         this.emit("message", data);
     }.bind(this));
 };

--- a/index.js
+++ b/index.js
@@ -56,10 +56,12 @@ Bot.prototype.connect = function() {
 
     this.ws.on('message', function(data) {
         try {
-            this.emit('message', JSON.parse(data));
+          data = JSON.parse(data);
         } catch (e) {
-            console.log(e);
+          console.log(e);
         }
+        this.emit(data.type, data);
+        this.emit("message", data);
     }.bind(this));
 };
 


### PR DESCRIPTION
First time I used this, listen `message` event and create response message, I meet is recursive loop of bot's self messages.

So I got some idea to add new events. For back ward compatible, I don't modify `message` event.
- `on_[event name]` - to listen events according to api.slack.rtm,
  - Example `on_message` `on_user_typing`
- `on_[event name]:[subtype]` - to listen events include subtype
  - Example `on_message:bot_message`
- `on_[event name];` - to listen events exclude subtype
  - Example `on_message;` that is which user typed messages
