### PR TITLE
Save `self` property received when doing `rtm.start` 

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ util.inherits(Bot, EventEmitter);
 Bot.prototype.login = function() {
     this._api('rtm.start').then(function(data) {
         this.wsUrl = data.url;
+        this.self = data.self;
         this.channels = data.channels;
         this.users = data.users;
         this.ims = data.ims;


### PR DESCRIPTION
As described here: https://api.slack.com/methods/rtm.start

This contains information about the bot `id` and `name` which is very useful.