### PR TITLE
Use POST instead of GET

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var request = require('request');
 var Vow = require('vow');
-var qs = require('querystring');
 var extend = require('extend');
 var WebSocket = require('ws');
 var util = require('util');
@@ -301,15 +300,14 @@ Bot.prototype.postTo = function(name, text, params, cb) {
 Bot.prototype._api = function(methodName, params) {
     params = extend(params || {}, {token: this.token});
 
-    var path = methodName + '?' + qs.stringify(params);
-
     var data = {
-        url: 'https://slack.com/api/' + path
+        url: 'https://slack.com/api/' + methodName,
+        form: params
     };
 
     return new Vow.Promise(function(resolve, reject) {
 
-        request.get(data, function(err, request, body) {
+        request.post(data, function(err, request, body) {
             if (err) {
                 reject(err);
 

--- a/test/test.js
+++ b/test/test.js
@@ -46,7 +46,7 @@ describe('slack-bot-api', function() {
             });
 
             bot._api('method', {foo: 1, bar: 2, baz: 3}).always(function() {
-                expect(r1).to.equal(
+                expect(r1).to.deep.equal(
                     {
                         url: 'https://slack.com/api/method',
                         form: {

--- a/test/test.js
+++ b/test/test.js
@@ -34,25 +34,35 @@ describe('slack-bot-api', function() {
 
     describe('#_api', function() {
         afterEach(function() {
-            request.get.restore();
+            request.post.restore();
         });
 
         it('check url', function(done) {
             var r1;
 
-            sinon.stub(request, 'get', function(data, cb) {
+            sinon.stub(request, 'post', function(data, cb) {
                 r1 = data;
                 cb(null, null, '{}');
             });
 
             bot._api('method', {foo: 1, bar: 2, baz: 3}).always(function() {
-                expect(r1.url).to.equal('https://slack.com/api/method?foo=1&bar=2&baz=3&token=token');
+                expect(r1).to.equal(
+                    {
+                        url: 'https://slack.com/api/method',
+                        form: {
+                            foo: 1,
+                            bar: 2,
+                            baz: 3,
+                            token: 'token'
+                        }
+                    }
+                );
                 done();
             })
         });
 
         it('response without error', function(done) {
-            sinon.stub(request, 'get', function(data, cb) {
+            sinon.stub(request, 'post', function(data, cb) {
                 cb(null, null, "{\"ok\": true}");
             });
 
@@ -63,7 +73,7 @@ describe('slack-bot-api', function() {
         });
 
         it('response with error', function(done) {
-            sinon.stub(request, 'get', function(data, cb) {
+            sinon.stub(request, 'post', function(data, cb) {
                 cb(null, null, "{\"ok\": false}");
             });
 


### PR DESCRIPTION
When calling the Slack Web API, use POST instead of GET. This makes it possible to send larger messages.

Tests are not updated, and this has only been lightly tested.