### PR TITLE
Check error format to prevent error message to be swallwed by emitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ Bot.prototype.login = function() {
 
         this.connect();
     }.bind(this)).fail(function(data) {
-        this.emit('error', new Error(data.error));
+        this.emit('error', new Error(data.error ? data.error : data));
     }.bind(this)).done();
 };
 


### PR DESCRIPTION
I was debugging my code (made a stupid typo in a prototype) while following (and hacking) this tutorial : https://scotch.io/tutorials/building-a-slack-bot-with-node-js-and-chuck-norris-super-powers

My error was swallowed at this line as the `data` wasn't an object with an error, but an error.

This tiny patch prevent that, by forwarding the raw data if there's no data.error.