### PR TITLE
Clean channe/user/group name on post to

### DIFF
--- a/index.js
+++ b/index.js
@@ -387,12 +387,12 @@ class Bot extends EventEmitter {
     }
 
     _cleanName (name) {
-        if (name == undefined || name.lenght == 0) {
+        if (name === undefined || name.lenght === 0) {
             return name;
         }
 
         var firstCharacter = name[0];
-        if (firstCharacter == '#' || firstCharacter == '@') {
+        if (firstCharacter === '#' || firstCharacter === '@') {
             name = name.substring(1, name.lenght);
         }
         return name;

--- a/index.js
+++ b/index.js
@@ -392,13 +392,13 @@ class Bot extends EventEmitter {
      * @returns {string}
      */
     _cleanName (name) {
-        if (name === undefined || name.lenght === 0) {
+        if (typeof name === undefined || typeof name !== 'string') {
             return name;
         }
 
-        var firstCharacter = name[0];
+        var firstCharacter = name.charAt(0);
         if (firstCharacter === '#' || firstCharacter === '@') {
-            name = name.substring(1, name.lenght);
+            name = name.slice(1);
         }
         return name;
     }

--- a/index.js
+++ b/index.js
@@ -369,6 +369,8 @@ class Bot extends EventEmitter {
     postTo(name, text, params, cb) {
         return Vow.all([this.getChannels(), this.getUsers(), this.getGroups()]).then(function(data) {
 
+            name = this._cleanName(name);
+
             var all = [].concat(data[0].channels, data[1].members, data[2].groups);
             var result = _.find(all, {name: name});
 
@@ -382,6 +384,18 @@ class Bot extends EventEmitter {
                 return this.postMessageToUser(name, text, params, cb);
             }
         }.bind(this));
+    }
+
+    _cleanName (name) {
+        if (name == undefined || name.lenght == 0) {
+            return name;
+        }
+
+        var firstCharacter = name[0];
+        if (firstCharacter == '#' || firstCharacter == '@') {
+            name = name.substring(1, name.lenght);
+        }
+        return name;
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -392,7 +392,7 @@ class Bot extends EventEmitter {
      * @returns {string}
      */
     _cleanName (name) {
-        if (typeof name === undefined || typeof name !== 'string') {
+        if (typeof name !== 'string') {
             return name;
         }
 

--- a/index.js
+++ b/index.js
@@ -386,6 +386,11 @@ class Bot extends EventEmitter {
         }.bind(this));
     }
 
+    /**
+     * Remove @ or # character from group | channel | user name
+     * @param {string} name
+     * @returns {string}
+     */
     _cleanName (name) {
         if (name === undefined || name.lenght === 0) {
             return name;

--- a/test/test.js
+++ b/test/test.js
@@ -243,6 +243,13 @@ describe('slack-this.bot-api', function() {
 
             expect(this.bot._cleanName(input)).to.deep.equal(output);
         });
+
+        it('Middle with #', function() {
+            var input = 'gen#eral';
+            var output = 'gen#eral';
+
+            expect(this.bot._cleanName(input)).to.deep.equal(output);
+        });
     });
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -219,4 +219,30 @@ describe('slack-this.bot-api', function() {
             });
         });
     });
+
+    describe('#_cleanName', function() {
+        it('Start with #', function() {
+            var input = '#general';
+            var output = 'general';
+
+            expect(this.bot._cleanName(input)).to.deep.equal(output);
+        });
+
+        it('Start with @', function() {
+            var input = '@general';
+            var output = 'general';
+
+            expect(this.bot._cleanName(input)).to.deep.equal(output);
+        });
+
+        it('clean', function() {
+            var func = function() {};
+
+            var input = 'general';
+            var output = 'general';
+
+            expect(this.bot._cleanName(input)).to.deep.equal(output);
+        });
+    });
+
 });


### PR DESCRIPTION
Added function to clean the user/channel/group name before try to find the destination on posTo message.

Function clean any # (from groups or channels) or @ (from users mentions) at the beginning of the name to allow find the destination when comparing by name.

Sample: Bot is mentioned on #general channel, if you try to reply using source message from message incoming, you will have "#general" instead of "general" making the search of destination on postTo, assert.