### PR TITLE
Add disconnect flag for one time use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ It also exposes all opportunities of <a href="https://api.slack.com/rtm">Slack's
 npm install slackbots
 ```
 
+### Params
+- `token` (string) the slack token
+- `name` (string) the name of the bot
+- `disconnect` (boolean, defaults: `false`) whether to open websocket connection to listen to incoming messages, set to `true` for one time use
+
 ### Events
 
 - `start` - event fired, when Real Time Messaging API is started (via websocket),

--- a/index.js
+++ b/index.js
@@ -17,9 +17,12 @@ class Bot extends EventEmitter {
          super(params);
          this.token = params.token;
          this.name = params.name;
+         this.disconnect = params.disconnect;
 
          console.assert(params.token, 'token must be defined');
-         this.login();
+         if (!this.disconnect) {
+           this.login();
+         }
      }
 
     /**


### PR DESCRIPTION
Add a `disconnect` flag that defaults to `false` to follow current logic. Set to `true` to take advantage of one time use cases where a single post is only necessary. This is necessary to avoid open websocket connection that will hang the process.

closes #83 