### PR TITLE
Added reconnect function that uses rtm.connect to reconnect to slack api

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ npm install slackbots
 - `postMessageToGroup(name, message [, params, callback])` (return: promise) - posts a message to private group by name,
 - `postMessageToChannel(name, message [, params, callback])` (return: promise) - posts a message to channel by name.
 - `openIm(userId)` (return: promise) - opens a direct message channel with another member in the team
+- `reconnect()` - reconnects the slackbot to the slack channel after websocket connection times out
 
 ## Usage
 ```js
@@ -120,4 +121,3 @@ bot.postMessageToUser('user', 'hi').always(function(data) {
     // ...
 })
 ```
-

--- a/index.js
+++ b/index.js
@@ -72,6 +72,19 @@ class Bot extends EventEmitter {
          }.bind(this));
      }
 
+     /**
+      * Reconnect to Real Time Messaging api after connection is dropped
+      */
+     reconnect() {
+        this._api('rtm.connect').then((data) => {
+            this.wsUrl = data.url;
+            console.log(data)
+            this.connect()
+        }).fail((data) => {
+             this.emit('error', new Error(data.error ? data.error : data));
+         }).done();
+    }
+
     /**
      * Get channels
      * @returns {vow.Promise}


### PR DESCRIPTION
Newer versions of the Real Time Messaging api from Slack cause the url used by Slackbots to expire after a short amount of time. Calling this function when receiving a goodbye event will call rtm.connect and return and update a new url for the slack bot to use.